### PR TITLE
Migrate build to use Spring Develocity Conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,3 @@ springRelease {
 	dayOfWeek = 1
 	releaseVersionPrefix = "v"
 }
-
-if (hasProperty("buildScan")) {
-	buildScan {
-		termsOfServiceUrl = "https://gradle.com/terms-of-service"
-		termsOfServiceAgree = "yes"
-	}
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,7 @@ pluginManagement {
 }
 
 plugins {
-	id "com.gradle.enterprise" version "3.15.1"
-	id "io.spring.ge.conventions" version "0.0.14"
+	id "io.spring.develocity.conventions" version "0.0.22"
 }
 
 rootProject.name = "spring-security-release-tools"


### PR DESCRIPTION
This PR removes the old `io.spring.ge.conventions` plugin in favor of `io.spring.develocity.conventions`. Also, the explicit `com.gradle.enterprise` plugin is removed since it's now bundled with the conventions since [0.0.21](https://github.com/spring-io/develocity-conventions/releases/tag/v0.0.21). Finally, I removed the ToS agreement since it's not explicitly required when publishing scans to `https://ge.spring.io`.